### PR TITLE
Remove maxtasksperchild=1 from pool initialization

### DIFF
--- a/python/lsst/meas/mosaic/mosaicTask.py
+++ b/python/lsst/meas/mosaic/mosaicTask.py
@@ -541,7 +541,7 @@ class MosaicTask(pipeBase.CmdLineTask):
             params.append((sourceReader, dataRef))
 
         if numCoresForReadSource > 1:
-            pool = multiprocessing.Pool(processes=numCoresForReadSource, maxtasksperchild=1)
+            pool = multiprocessing.Pool(processes=numCoresForReadSource)
             worker = Worker()
             resultList = pool.map_async(worker, params).get(readTimeout)
             pool.close()


### PR DESCRIPTION
This keyword had been added by commit 2ecc8fd but it has been
identified to cause indefinite hanging of the mosaic.py script
when run with numCoresForRead > 1---but only with the pybind11
version of the stack.  This is not a problem in the swig-wrapped
code (currently being used for the HSC pipeline stack).