### PR TITLE
DM-11138: Add jointcal_ prefixes to wcs and photoCalib datasets.

### DIFF
--- a/python/lsst/meas/mosaic/calibrate.py
+++ b/python/lsst/meas/mosaic/calibrate.py
@@ -20,7 +20,7 @@ class CalibrateCatalogTask(CmdLineTask):
     @classmethod
     def _makeArgumentParser(cls):
         parser = ArgumentParser(name=cls._DefaultName)
-        parser.add_id_argument("--id", "wcs", help="data ID, with raw CCD keys + tract",
+        parser.add_id_argument("--id", "jointcal_wcs", help="data ID, with raw CCD keys + tract",
                                ContainerClass=PerTractCcdDataIdContainer)
         return parser
 
@@ -55,7 +55,7 @@ class CalibrateExposureTask(CmdLineTask):
     @classmethod
     def _makeArgumentParser(cls):
         parser = ArgumentParser(name=cls._DefaultName)
-        parser.add_id_argument("--id", "wcs", help="data ID, with raw CCD keys + tract",
+        parser.add_id_argument("--id", "jointcal_wcs", help="data ID, with raw CCD keys + tract",
                                ContainerClass=PerTractCcdDataIdContainer)
         return parser
 

--- a/python/lsst/meas/mosaic/checkMosaicTask.py
+++ b/python/lsst/meas/mosaic/checkMosaicTask.py
@@ -451,13 +451,13 @@ class CheckMosaicTask(MosaicTask):
                 if not dataRef.datasetExists('src'):
                     raise RuntimeError("no data for src %s" % (dataRef.dataId))
 
-                if not dataRef.datasetExists('wcs'):
+                if not dataRef.datasetExists('jointcal_wcs'):
                     raise RuntimeError("no data for wcs %s" % (dataRef.dataId))
 
                 if not dataRef.datasetExists('fcr'):
                     raise RuntimeError("no data for fcr %s" % (dataRef.dataId))
 
-                wcs = dataRef.get('wcs').getWcs()
+                wcs = dataRef.get('jointcal_wcs')
 
                 md = dataRef.get('calexp_md')
                 filterName = afwImage.Filter(md).getName()

--- a/python/lsst/meas/mosaic/mosaicTask.py
+++ b/python/lsst/meas/mosaic/mosaicTask.py
@@ -473,7 +473,7 @@ class MosaicTask(pipeBase.CmdLineTask):
     @classmethod
     def _makeArgumentParser(cls):
         parser = pipeBase.ArgumentParser(name=cls._DefaultName)
-        parser.add_id_argument("--id", "wcs", help="data ID, with raw CCD keys + tract",
+        parser.add_id_argument("--id", "jointcal_wcs", help="data ID, with raw CCD keys + tract",
                                ContainerClass=PerTractCcdDataIdContainer)
         parser.add_argument("--diagDir", default=".", help="Directory in which to dump diagnostics")
         parser.add_argument("--diagnostics", default=False, action="store_true",
@@ -615,7 +615,6 @@ class MosaicTask(pipeBase.CmdLineTask):
 
     def writeNewWcs(self, dataRefList):
         self.log.info("Write New WCS ...")
-        exp = afwImage.ExposureI(0, 0)
         for dataRef in dataRefList:
             iexp = dataRef.dataId["visit"]
             ichip = dataRef.dataId["ccd"]
@@ -632,9 +631,8 @@ class MosaicTask(pipeBase.CmdLineTask):
                         dimensions = afwGeom.Extent2I(dimensions.getY(), dimensions.getX())
                     wcs = measAstrom.rotateWcsPixelsBy90(wcs, 4 - nQuarter, dimensions)
 
-            exp.setWcs(wcs)
             try:
-                dataRef.put(exp, "wcs")
+                dataRef.put(wcs, "jointcal_wcs")
             except Exception as e:
                 print("failed to write wcs: %s" % (e))
 
@@ -687,7 +685,7 @@ class MosaicTask(pipeBase.CmdLineTask):
                 # it should be in the noise of the overall runtime and it
                 # saves us from doing a bunch of refactoring in a fragile
                 # package with no tests.
-                wcs = dataRef.get("wcs").getWcs()
+                wcs = dataRef.get("jointcal_wcs")
             except Exception as e:
                 print("failed to read Wcs for PhotoCalib: %s" % (e))
                 continue
@@ -701,7 +699,7 @@ class MosaicTask(pipeBase.CmdLineTask):
                 bf,
                 isConstant=False
             )
-            dataRef.put(photoCalib, "photoCalib")
+            dataRef.put(photoCalib, "jointcal_photoCalib")
 
     def outputDiagWcs(self):
         self.log.info("Output WCS Diagnostic Figures...")

--- a/python/lsst/meas/mosaic/updateExposure.py
+++ b/python/lsst/meas/mosaic/updateExposure.py
@@ -28,6 +28,7 @@ import lsst.afw.table as afwTable
 import lsst.afw.image as afwImage
 import lsst.afw.math as afwMath
 from lsst.pipe.base import Struct, TaskError
+from lsst.daf.persistence import NoResults
 from . import utils as mosaicUtils
 
 __all__ = ("applyMosaicResults", "getMosaicResults", "applyMosaicResultsExposure",
@@ -122,8 +123,14 @@ def getWcs(dataRef):
     calexp_md = dataRef.get("calexp_md", immediate=True)
     hscRun = mosaicUtils.checkHscStack(calexp_md)
     if hscRun is not None:
+        # Backwards compatibility with the very oldest meas_mosaic outputs
         return dataRef.get("wcs_hsc").getWcs()
-    return dataRef.get("wcs").getWcs()
+    try:
+        # Modern meas_mosaic outputs.
+        return dataRef.get("jointcal_wcs")
+    except NoResults:
+        # Backwards compatibility with old meas_mosaic outputs
+        return dataRef.get("wcs").getWcs()
 
 
 def getMosaicResults(dataRef, dims=None):

--- a/tests/test_fluxFitBoundedField.py
+++ b/tests/test_fluxFitBoundedField.py
@@ -26,6 +26,7 @@ import os
 import unittest
 import numpy as np
 
+from lsst.daf.persistence import NoResults
 import lsst.afw.geom
 import lsst.afw.image
 from lsst.afw.fits import readMetadata
@@ -104,7 +105,10 @@ class MockDataRef(object):
         self.datasets = {}
 
     def get(self, name, immediate=True):
-        return self.datasets[name]
+        try:
+            return self.datasets[name]
+        except KeyError as err:
+            raise NoResults(str(err), name, self.dataId)
 
     def put(self, dataset, name):
         self.datasets[name] = dataset


### PR DESCRIPTION
fcr is left unchanged; it's already semi-deprecated in favor of photoCalib (now jointcal_photoCalib).

The test and display code that uses old outputs committed to this repository has also been left unchanged.