### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/meas/mosaic/FluxFitBoundedField.h
+++ b/include/lsst/meas/mosaic/FluxFitBoundedField.h
@@ -60,7 +60,7 @@ public:
     using afw::math::BoundedField::evaluate;
 
     /// FluxFitBoundedField is always persistable.
-    bool isPersistable() const override { return true; }
+    bool isPersistable() const noexcept override { return true; }
 
     /// @copydoc BoundedField::operator*
     std::shared_ptr<afw::math::BoundedField> operator*(double const scale) const override;


### PR DESCRIPTION
lsst/afw#366 adds a `noexcept` specifier to `afw::table::io::Persistence::isPersistable`. This PR adds a `noexcept` specifier to all methods that override `Persistence::isPersistable`, as required by type safety.